### PR TITLE
Fix text wrapping

### DIFF
--- a/index.html
+++ b/index.html
@@ -87,7 +87,7 @@
 
   <h1>Gillian Sibthorpe</h1>
 
-  <h2>Digital Project Manager, Certified Scrum Master</h2>
+  <h2>Digital Project Manager, Certified&nbsp;Scrum&nbsp;Master</h2>
 
   <ul>
     <li>


### PR DESCRIPTION
On smaller screens, job titles were wrapping over multiple lines and creating
widows. I’ve put some non-breaking spaces into the markup to prevent this from
happening.
